### PR TITLE
Requests & Cleanup

### DIFF
--- a/BetterMenus/Elements/CustomSlider.cs
+++ b/BetterMenus/Elements/CustomSlider.cs
@@ -152,11 +152,15 @@ namespace Satchel.BetterMenus
 
         public override void Update()
         {
-            //change Text
-            GetLabel().text = Name;
-            SetValueLabel(value);
+            
             var slider = GetSlider();
+            //update value
+            value = SavedValue.Invoke();
             slider.value = value;
+            //change Text
+            GetLabel().text = $"{Name}"; 
+            SetValueLabel(value);
+            
             slider.minValue = minValue;                
             slider.maxValue = maxValue;                
             slider.wholeNumbers = wholeNumbers;

--- a/Futils/Extractors/AudioClips.cs
+++ b/Futils/Extractors/AudioClips.cs
@@ -9,50 +9,77 @@ namespace Satchel.Futils.Extractors
                     Type t = action.GetType();
                     if (action is AudioPlay){
                         AudioPlay a = (AudioPlay) action;
-                        if(a.oneShotClip == null){ continue; }
+                        if(a.oneShotClip == null){ 
+                            Modding.Logger.LogFine($"clip null in action {action.Name}");
+                            continue; 
+                        }
                         var clip = a.oneShotClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if(action is AudioPlayerOneShot){
                         AudioPlayerOneShot a = (AudioPlayerOneShot) action;
                         foreach( var clip in a.audioClips){
-                            if(clip == null){ continue; }
+                            if(clip == null){ 
+                                Modding.Logger.LogFine($"clip null in action {action.Name}");
+                                continue; 
+                            }
                             ac[clip.name]=clip;
                         }
                     }  else if(action is AudioPlayerOneShotSingle){
                         AudioPlayerOneShotSingle a = (AudioPlayerOneShotSingle) action;
-                        if(a.audioClip == null){ continue; }
+                        if(a.audioClip == null){ 
+                            Modding.Logger.LogFine($"clip null in action {action.Name}");
+                            continue; 
+                        }
                         var clip = a.audioClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is AudioPlayRandom){
                         AudioPlayRandom a = (AudioPlayRandom) action;
                         foreach( var clip in a.audioClips){
-                            if(clip == null){ continue; }
+                            if(clip == null){ 
+                                Modding.Logger.LogFine($"clip null in action {action.Name}");
+                                continue; 
+                            }
                             ac[clip.name]=clip;
                         }
                     } else if (action is AudioPlayRandomSingle){
                         AudioPlayRandomSingle a = (AudioPlayRandomSingle) action;
-                        if(a.audioClip == null){ continue; }
+                        if(a.audioClip == null){ 
+                            Modding.Logger.LogFine($"clip null in action {action.Name}");
+                            continue; 
+                        }
                         var clip = a.audioClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is AudioPlaySimple){
                         AudioPlaySimple a = (AudioPlaySimple) action;
-                        if(a.oneShotClip == null){ continue; }
+                        if(a.oneShotClip == null){ 
+                            Modding.Logger.LogFine($"clip null in action {action.Name}");
+                            continue; 
+                        }
                         var clip = a.oneShotClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is AudioPlayV2){
                         AudioPlayV2 a = (AudioPlayV2) action;
-                        if(a.oneShotClip == null){ continue; }
+                        if(a.oneShotClip == null){ 
+                            Modding.Logger.LogFine($"clip null in action {action.Name}");
+                            continue; 
+                        }
                         var clip = a.oneShotClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is PlayRandomSound){
                         PlayRandomSound a = (PlayRandomSound) action;
                         foreach( var clip in a.audioClips){
-                            if(clip == null){ continue; }
+                            if(clip == null){ 
+                                Modding.Logger.LogFine($"clip null in action {action.Name}");
+                                continue; 
+                            }
                             ac[clip.name]=clip;
                         }
                     } else if (action is PlaySound){
                         PlaySound a = (PlaySound) action;
-                        if(a.clip == null){ continue; }
+                        if(a.clip == null){ 
+                            Modding.Logger.LogFine($"clip null in action {action.Name}");
+                            continue; 
+                        }
                         var clip = a.clip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } 

--- a/Futils/Extractors/AudioClips.cs
+++ b/Futils/Extractors/AudioClips.cs
@@ -9,41 +9,50 @@ namespace Satchel.Futils.Extractors
                     Type t = action.GetType();
                     if (action is AudioPlay){
                         AudioPlay a = (AudioPlay) action;
+                        if(a.oneShotClip == null){ continue; }
                         var clip = a.oneShotClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if(action is AudioPlayerOneShot){
                         AudioPlayerOneShot a = (AudioPlayerOneShot) action;
                         foreach( var clip in a.audioClips){
+                            if(clip == null){ continue; }
                             ac[clip.name]=clip;
                         }
                     }  else if(action is AudioPlayerOneShotSingle){
                         AudioPlayerOneShotSingle a = (AudioPlayerOneShotSingle) action;
+                        if(a.audioClip == null){ continue; }
                         var clip = a.audioClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is AudioPlayRandom){
                         AudioPlayRandom a = (AudioPlayRandom) action;
                         foreach( var clip in a.audioClips){
+                            if(clip == null){ continue; }
                             ac[clip.name]=clip;
                         }
                     } else if (action is AudioPlayRandomSingle){
                         AudioPlayRandomSingle a = (AudioPlayRandomSingle) action;
+                        if(a.audioClip == null){ continue; }
                         var clip = a.audioClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is AudioPlaySimple){
                         AudioPlaySimple a = (AudioPlaySimple) action;
+                        if(a.oneShotClip == null){ continue; }
                         var clip = a.oneShotClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is AudioPlayV2){
                         AudioPlayV2 a = (AudioPlayV2) action;
+                        if(a.oneShotClip == null){ continue; }
                         var clip = a.oneShotClip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } else if (action is PlayRandomSound){
                         PlayRandomSound a = (PlayRandomSound) action;
                         foreach( var clip in a.audioClips){
+                            if(clip == null){ continue; }
                             ac[clip.name]=clip;
                         }
                     } else if (action is PlaySound){
                         PlaySound a = (PlaySound) action;
+                        if(a.clip == null){ continue; }
                         var clip = a.clip.Value as AudioClip;
                         ac[clip.name]=clip;
                     } 

--- a/Futils/FsmUtils.cs
+++ b/Futils/FsmUtils.cs
@@ -132,10 +132,8 @@ namespace Satchel
         public static void ChangeTransition(this FsmState state, string onEventName, string toStateName)
         {
             var transition = state.GetTransition(onEventName);
-            if(transition != null){
-                transition.ToState = toStateName;
-                transition.ToFsmState = state.Fsm.GetState(toStateName);
-            }
+            transition.ToState = toStateName;
+            transition.ToFsmState = state.Fsm.GetState(toStateName);
         }
         public static void ChangeTransition(this PlayMakerFSM fsm, string fromStateName, string onEventName, string toStateName)
         {

--- a/Futils/FsmUtils.cs
+++ b/Futils/FsmUtils.cs
@@ -245,6 +245,14 @@ namespace Satchel
         {
             fsm.GetState(stateName).AddAction(new CustomFsmAction() { method = method });
         }
+
+        public static void AddCustomAction(this FsmState state, string stateName, Action<FsmState> method){
+            state.AddAction(new CustomFsmAction() { method = () => method(state) });
+        }
+        public static void AddCustomAction(this PlayMakerFSM fsm, string stateName, Action<PlayMakerFSM> method)
+        {
+            fsm.GetState(stateName).AddAction(new CustomFsmAction() { method = () => method(fsm) });
+        }
         public static void InsertCustomAction(this FsmState state, string stateName, Action method, int index)
         {
             state.InsertAction(new CustomFsmAction() { method = method },index);
@@ -253,7 +261,14 @@ namespace Satchel
         {
             fsm.GetState(stateName).InsertAction(new CustomFsmAction() { method = method },index);
         }
-
+        public static void InsertCustomAction(this FsmState state, string stateName, Action<FsmState> method, int index)
+        {
+            state.InsertAction(new CustomFsmAction() { method = () => method(state) },index);
+        }
+        public static void InsertCustomAction(this PlayMakerFSM fsm, string stateName, Action<PlayMakerFSM> method, int index)
+        {
+            fsm.GetState(stateName).InsertAction(new CustomFsmAction() { method = () => method(fsm) },index);
+        }
     }
 
 }

--- a/Futils/Serialiser/FSMSerialiser.cs
+++ b/Futils/Serialiser/FSMSerialiser.cs
@@ -7,7 +7,6 @@ namespace Satchel.Futils.Serialiser{
             var _actionNames = ReflectionHelper.GetField<HutongGames.PlayMaker.ActionData, List<string>>(ActionData, "actionNames");
             Modding.Logger.Log(_actionNames[i] + " | " + ase.Name );
             if(ase.Name != _actionNames[i]){ 
-                Modding.Logger.Log("returned");
                 return ase; 
             }
             var _paramName = ReflectionHelper.GetField<HutongGames.PlayMaker.ActionData, List<string>>(ActionData, "paramName");
@@ -26,7 +25,6 @@ namespace Satchel.Futils.Serialiser{
                 string paramName = _paramName[j];
                 object obj = ActionReader.GetFsmObject(ActionData, j, dataVersion);
             
-                Modding.Logger.Log(paramName);
                 ase.Values.Add(new Tuple<string, object>(paramName, obj));
             }
             return ase;

--- a/HKMP/Pipe.cs
+++ b/HKMP/Pipe.cs
@@ -23,7 +23,6 @@ namespace Satchel.HkmpPipe{
         }
 
         internal void handleRecieve(GenericPacket p){
-            Modding.Logger.LogDebug($"packet from {p.fromPlayer} : event {p.eventName} : data {p.eventData}");
             if(p.mod != this.mod) { return; } // only recieve your own mods events
             OnRecieve?.Invoke(this,new RecievedEventArgs{
                 packet = p

--- a/HKMP/Server.cs
+++ b/HKMP/Server.cs
@@ -50,7 +50,7 @@ namespace Satchel.HkmpPipe{
 
             netReceiver.RegisterPacketHandler<GenericPacket>(
                 Packets.GenericPacket,
-                async (id, packetData) => {
+                (id, packetData) => {
                     //broadcast the packet to all server addons
                     OnRecieve?.Invoke(this,new RecievedEventArgs{
                         packet = packetData

--- a/Monobehaviour/CustomAnimationController.cs
+++ b/Monobehaviour/CustomAnimationController.cs
@@ -46,7 +46,6 @@ namespace Satchel
             if(sr == null){
                 sr = GetComponent<SpriteRenderer>();
             }
-            Debug.Log($"currentFrame: {currentFrame} | sprites.Length: {sprites.Length}");
             sr.sprite = sprites[currentFrame];
 
         }

--- a/Utils/AssemblyUtils.cs
+++ b/Utils/AssemblyUtils.cs
@@ -98,5 +98,27 @@ namespace Satchel
             return bundle.LoadAsset<Shader>(shader);
         }
 
+        public static void ExtractFiles(this Assembly asm,string outpath,Func<string,string> shouldExtractAs){
+            IoUtils.EnsureDirectory(outpath);
+            foreach (string res in asm.GetManifestResourceNames())
+            {   
+                var fileName = shouldExtractAs(res);
+                if(fileName != "") {
+                    using (Stream s = asm.GetManifestResourceStream(res))
+                    {
+                            if (s == null) continue;
+                            var buffer = new byte[s.Length];
+                            s.Read(buffer, 0, buffer.Length);
+                            File.WriteAllBytes(Path.Combine(outpath,fileName),buffer);
+                            s.Dispose();
+                    }
+                } 
+            }
+        }
+
+        public static void ExtractFiles(string outpath,Func<string,string> shouldExtractAs){
+            Assembly.GetCallingAssembly().ExtractFiles(outpath,shouldExtractAs);
+        }
+
     }
 }

--- a/Utils/AssemblyUtils.cs
+++ b/Utils/AssemblyUtils.cs
@@ -6,7 +6,7 @@ namespace Satchel
 {
     public static class AssemblyUtils{
         public static string name = "Satchel";
-        public static string ver = "0.7.6";
+        public static string ver = "0.8.0";
         public static string Version(){
             var verStr = $"{name} v{ver}";
             return verStr;

--- a/Utils/SpriteUtils.cs
+++ b/Utils/SpriteUtils.cs
@@ -78,7 +78,7 @@ namespace Satchel
                 maskMat.SetVector("_P2", mp2);
                 Graphics.Blit(mtex2, mtex, maskMat);
                 Graphics.Blit(mtex, mtex2);
-                Modding.Logger.Log($"triangles: {mp0} {mp1} {mp2}");
+                //Modding.Logger.Log($"triangles: {mp0} {mp1} {mp2}");
             }
             
             UnityEngine.Object.Destroy(maskMat);

--- a/Utils/SpriteUtils.cs
+++ b/Utils/SpriteUtils.cs
@@ -125,7 +125,7 @@ namespace Satchel
             #endregion
             return readableText;
         }
-        public static Texture2D ExtractTextureFromSprite(Sprite testSprite, bool saveTriangles = false)
+        public static Texture2D ExtractTextureFromSpriteExperimental(Sprite testSprite, bool saveTriangles = false)
         {
             var testSpriteRect = (testSprite.texture.width, testSprite.texture.height);
             List<Vector2Int> texUVs = new List<Vector2Int>();
@@ -385,6 +385,11 @@ namespace Satchel
             
             Texture2D.DestroyImmediate(origTex);
             return outTex;
+        }
+    
+        public static Texture2D ExtractTextureFromSprite(Sprite testSprite, bool saveTriangles = false)
+        {
+            return ExtractTextureFromSpriteLegacy(testSprite,saveTriangles); // use legacy mode till the experimental one is fixed
         }
     }
 

--- a/Utils/TextureUtils.cs
+++ b/Utils/TextureUtils.cs
@@ -88,7 +88,7 @@ namespace Satchel
         }
 
         public static string getHash(this Texture2D tex){ 
-            var data = tex.GetRawTextureData();
+            var data = tex.EncodeToPNG();
             var sha1 = SHA1.Create();
 
             byte[] hashBytes = sha1.ComputeHash(data);


### PR DESCRIPTION
- remove null check to avoid eating errors
- fix for custom slider retaining initial value on update
- pass a reference to the fsm or the state into the custom action delegate
- add null checks to audio clip extractor
- add file extractor from resources
- clean up
