### PR TITLE
Make CustomSlider::UpdateValueLabel overridable

### DIFF
--- a/BetterMenus/Elements/CustomSlider.cs
+++ b/BetterMenus/Elements/CustomSlider.cs
@@ -240,7 +240,7 @@ namespace Satchel.BetterMenus
             }
         }
 
-        private void UpdateValueLabel()
+        protected virtual void UpdateValueLabel()
         {
             valueLabel.text = wholeNumbers ? $"{value}" : $"{value:0.0}";
         }


### PR DESCRIPTION
Change access modifier to protected so that subclasses can access it and mark virtual so that it is overridable for custom value formatting.